### PR TITLE
feat: improve menu accessibility for mobile navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
                 <a href="#contact" class="bg-teal-500 text-white px-4 py-2 rounded-full hover:bg-teal-600 transition duration-300">যোগাযোগ করুন</a>
             </div>
             <div class="md:hidden">
-                <button id="menu-btn" class="text-gray-600 focus:outline-none">
+                <button id="menu-btn" class="text-gray-600 focus:outline-none" aria-label="মেনু খুলুন বা বন্ধ করুন" aria-expanded="false">
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path></svg>
                 </button>
             </div>
@@ -397,6 +397,8 @@
         const menuBtn = document.getElementById('menu-btn');
         const mobileMenu = document.getElementById('mobile-menu');
         menuBtn.addEventListener('click', () => {
+            const expanded = menuBtn.getAttribute('aria-expanded') === 'true';
+            menuBtn.setAttribute('aria-expanded', (!expanded).toString());
             mobileMenu.classList.toggle('hidden');
         });
 


### PR DESCRIPTION
## Summary
- add descriptive `aria-label` to the mobile menu button
- toggle `aria-expanded` to reflect menu state

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Digital-Care/package.json')*

------
https://chatgpt.com/codex/tasks/task_b_689f1e0c6ac4832a912e4358e26dde5b