### PR TITLE
Change site name color when header reaches contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <!-- Header / Navbar -->
     <header class="bg-white/30 backdrop-blur-md border border-white/20 shadow-sm sticky top-0 z-50">
         <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
-            <a href="#" class="text-2xl font-bold text-teal-600">ডিজিটাল কেয়ার</a>
+            <a href="#" id="site-name" class="text-2xl font-bold text-teal-600">ডিজিটাল কেয়ার</a>
             <div class="hidden md:flex space-x-6 items-center">
                 <a href="#services" class="text-gray-600 hover:text-teal-600">সার্ভিসসমূহ</a>
                 <a href="#pricing" class="text-gray-600 hover:text-teal-600">মূল্য তালিকা</a>

--- a/main.js
+++ b/main.js
@@ -126,13 +126,11 @@ if (orderForm) {
     });
 }
 
-// Change site name color when header reaches the contact section
+// Change site name color when footer is in view
 const siteName = document.getElementById('site-name');
-const contactSection = document.getElementById('contact');
-const header = document.querySelector('header');
+const footer = document.querySelector('footer');
 
-if (siteName && contactSection && header) {
-    const headerHeight = header.offsetHeight;
+if (siteName && footer) {
     const observer = new IntersectionObserver((entries) => {
         entries.forEach(entry => {
             if (entry.isIntersecting) {
@@ -143,11 +141,8 @@ if (siteName && contactSection && header) {
                 siteName.classList.add('text-teal-600');
             }
         });
-    }, {
-        rootMargin: `-${headerHeight}px 0px 0px 0px`,
-        threshold: 0
-    });
+    }, { threshold: 0.1 });
 
-    observer.observe(contactSection);
+    observer.observe(footer);
 }
 

--- a/main.js
+++ b/main.js
@@ -126,3 +126,28 @@ if (orderForm) {
     });
 }
 
+// Change site name color when header reaches the contact section
+const siteName = document.getElementById('site-name');
+const contactSection = document.getElementById('contact');
+const header = document.querySelector('header');
+
+if (siteName && contactSection && header) {
+    const headerHeight = header.offsetHeight;
+    const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                siteName.classList.remove('text-teal-600');
+                siteName.classList.add('text-white');
+            } else {
+                siteName.classList.remove('text-white');
+                siteName.classList.add('text-teal-600');
+            }
+        });
+    }, {
+        rootMargin: `-${headerHeight}px 0px 0px 0px`,
+        threshold: 0
+    });
+
+    observer.observe(contactSection);
+}
+


### PR DESCRIPTION
## Summary
- Use contact section rather than footer to trigger site name color swap
- Observe contact section and adjust color when header overlaps it

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689fd99d7390832a83a4830084838c79