### PR TITLE
Add separate pages for key services

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
                         <div class="flex justify-center mb-4">
                              <svg class="w-16 h-16 text-teal-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path></svg>
                         </div>
-                        <h3 class="text-xl font-bold mb-2">ওয়েবসাইট সেটআপ</h3>
+                        <h3 class="text-xl font-bold mb-2"><a href="services/web-development.html" class="hover:text-teal-600">ওয়েবসাইট সেটআপ</a></h3>
                         <p class="text-gray-600">আপনার ব্যবসার জন্য একটি তথ্যবহুল, ইউজার-ফ্রেন্ডলি এবং আধুনিক ডিজাইনের রেসপন্সিভ ওয়েবসাইট তৈরি।</p>
                     </div>
                     <!-- Service Card 2 -->
@@ -98,7 +98,7 @@
                         <div class="flex justify-center mb-4">
                             <svg class="w-16 h-16 text-teal-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
                         </div>
-                        <h3 class="text-xl font-bold mb-2">AI কাস্টমার সার্ভিস</h3>
+                        <h3 class="text-xl font-bold mb-2"><a href="services/ai-chatbot.html" class="hover:text-teal-600">AI কাস্টমার সার্ভিস</a></h3>
                         <p class="text-gray-600">আমাদের তৈরি AI এজেন্ট ২৪/৭ গ্রাহকদের সাধারণ প্রশ্নের উত্তর দেবে, অ্যাপয়েন্টমেন্ট বা অর্ডার নিতে সাহায্য করবে এবং তথ্য প্রদান করবে।</p>
                     </div>
                     <!-- Service Card 4 -->
@@ -106,7 +106,7 @@
                         <div class="flex justify-center mb-4">
                              <svg class="w-16 h-16 text-teal-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"></path></svg>
                         </div>
-                        <h3 class="text-xl font-bold mb-2">ডিজিটাল মার্কেটিং</h3>
+                        <h3 class="text-xl font-bold mb-2"><a href="services/digital-marketing.html" class="hover:text-teal-600">ডিজিটাল মার্কেটিং</a></h3>
                         <p class="text-gray-600">ফেসবুক ও গুগলে বিজ্ঞাপনের মাধ্যমে আপনার হাসপাতালের পরিচিতি বাড়ানো এবং আরও বেশি গ্রাহকের কাছে পৌঁছানো।</p>
                     </div>
                 </div>

--- a/services/ai-chatbot.html
+++ b/services/ai-chatbot.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="bn" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="ডিজিটাল কেয়ার সলিউশনস এর AI চ্যাটবট সার্ভিস">
+    <title>AI চ্যাটবট - ডিজিটাল কেয়ার সলিউশনস</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+        body { font-family: 'Hind Siliguri', sans-serif; }
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+    <header class="bg-white/30 backdrop-blur-md border border-white/20 shadow-sm sticky top-0 z-50">
+        <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../index.html" id="site-name" class="text-2xl font-bold text-teal-600">ডিজিটাল কেয়ার</a>
+            <div class="hidden md:flex space-x-6 items-center">
+                <a href="../about.html" class="text-gray-600 hover:text-teal-600">আমাদের সম্পর্কে</a>
+                <a href="../index.html#services" class="text-gray-600 hover:text-teal-600">সার্ভিসসমূহ</a>
+                <a href="../index.html#pricing" class="text-gray-600 hover:text-teal-600">মূল্য তালিকা</a>
+                <a href="../index.html#process" class="text-gray-600 hover:text-teal-600">আমাদের প্রক্রিয়া</a>
+                <a href="../index.html#faq" class="text-gray-600 hover:text-teal-600">জিজ্ঞাসা</a>
+                <a href="../index.html#contact" class="bg-teal-500 text-white px-4 py-2 rounded-full hover:bg-teal-600 transition duration-300">যোগাযোগ করুন</a>
+            </div>
+            <div class="md:hidden">
+                <button id="menu-btn" class="text-gray-600 focus:outline-none" aria-label="মেনু খুলুন বা বন্ধ করুন" aria-expanded="false">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path></svg>
+                </button>
+            </div>
+        </nav>
+        <div id="mobile-menu" class="md:hidden hidden px-6 pb-4 space-y-2">
+            <a href="../about.html" class="block text-gray-600 hover:text-teal-600">আমাদের সম্পর্কে</a>
+            <a href="../index.html#services" class="block text-gray-600 hover:text-teal-600">সার্ভিসসমূহ</a>
+            <a href="../index.html#pricing" class="block text-gray-600 hover:text-teal-600">মূল্য তালিকা</a>
+            <a href="../index.html#process" class="block text-gray-600 hover:text-teal-600">আমাদের প্রক্রিয়া</a>
+            <a href="../index.html#faq" class="block text-gray-600 hover:text-teal-600">জিজ্ঞাসা</a>
+            <a href="../index.html#contact" class="block bg-teal-500 text-white text-center px-4 py-2 rounded-full hover:bg-teal-600 transition duration-300">যোগাযোগ করুন</a>
+        </div>
+    </header>
+
+    <main>
+        <section class="bg-white py-20">
+            <div class="container mx-auto px-6 text-center">
+                <h1 class="text-4xl md:text-5xl font-bold text-gray-800">AI চ্যাটবট</h1>
+                <p class="text-lg text-gray-600 mt-4 max-w-3xl mx-auto">২৪/৭ গ্রাহক সেবা, অ্যাপয়েন্টমেন্ট বুকিং এবং সাধারণ প্রশ্নের উত্তর দিতে আমাদের বুদ্ধিমান AI চ্যাটবট ব্যবহার করুন।</p>
+            </div>
+        </section>
+        <section class="py-20">
+            <div class="container mx-auto px-6">
+                <h2 class="text-3xl font-bold mb-6 text-center">আমাদের সেবার বৈশিষ্ট্য</h2>
+                <ul class="list-disc list-inside text-gray-600 space-y-2 max-w-3xl mx-auto">
+                    <li>বাংলা ও ইংরেজিতে কথোপকথন</li>
+                    <li>সাধারণ প্রশ্নের তাৎক্ষণিক উত্তর</li>
+                    <li>অ্যাপয়েন্টমেন্ট ও অর্ডার ম্যানেজমেন্ট</li>
+                    <li>সিআরএম বা অন্যান্য সিস্টেমের সাথে ইন্টিগ্রেশন</li>
+                </ul>
+            </div>
+        </section>
+    </main>
+
+    <footer class="bg-gray-800 text-white pt-16 pb-8">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
+                <div class="md:col-span-2">
+                    <h3 class="text-xl font-bold text-teal-500 mb-4">ডিজিটাল কেয়ার সলিউশনস</h3>
+                    <p class="text-gray-400">আমরা বাংলাদেশের স্বাস্থ্যসেবা প্রতিষ্ঠানগুলোকে আধুনিক প্রযুক্তির মাধ্যমে ডিজিটাল জগতে সফল হতে সাহায্য করি। আমাদের লক্ষ্য হলো আপনার এবং আপনার রোগীদের মধ্যে একটি নির্ভরযোগ্য ডিজিটাল সেতু তৈরি করা।</p>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">গুরুত্বপূর্ণ লিংক</h3>
+                    <ul class="space-y-2">
+                        <li><a href="../about.html" class="text-gray-400 hover:text-white">আমাদের সম্পর্কে</a></li>
+                        <li><a href="../index.html#services" class="text-gray-400 hover:text-white">সার্ভিসসমূহ</a></li>
+                        <li><a href="../index.html#pricing" class="text-gray-400 hover:text-white">মূল্য তালিকা</a></li>
+                        <li><a href="../index.html#process" class="text-gray-400 hover:text-white">আমাদের প্রক্রিয়া</a></li>
+                        <li><a href="../index.html#faq" class="text-gray-400 hover:text-white">সাধারণ জিজ্ঞাসা</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">যোগাযোগ</h3>
+                    <ul class="space-y-2 text-gray-400">
+                        <li class="flex items-start"><i class="fas fa-map-marker-alt mt-1 mr-2"></i>ডিকেপি রোড, বরগুনা</li>
+                        <li class="flex items-start"><i class="fas fa-phone mt-1 mr-2"></i>01639590392</li>
+                        <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2"></i>rahmatullahzisan@gmail.com</li>
+                    </ul>
+                    <div class="mt-4 flex space-x-4">
+                        <a href="#" class="text-gray-400 hover:text-white"><i class="fab fa-facebook-f fa-lg"></i></a>
+                        <a href="#" class="text-gray-400 hover:text-white"><i class="fab fa-linkedin-in fa-lg"></i></a>
+                        <a href="#" class="text-gray-400 hover:text-white"><i class="fab fa-youtube fa-lg"></i></a>
+                    </div>
+                </div>
+            </div>
+            <div class="border-t border-gray-700 pt-6 text-center text-gray-500">
+                <p>&copy; <span id="currentYear"></span> ডিজিটাল কেয়ার সলিউশনস। সর্বস্বত্ব সংরক্ষিত।</p>
+            </div>
+        </div>
+    </footer>
+    <script src="../main.js" defer></script>
+</body>
+</html>

--- a/services/digital-marketing.html
+++ b/services/digital-marketing.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="bn" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="ডিজিটাল কেয়ার সলিউশনস এর ডিজিটাল মার্কেটিং সার্ভিস">
+    <title>ডিজিটাল মার্কেটিং - ডিজিটাল কেয়ার সলিউশনস</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+        body { font-family: 'Hind Siliguri', sans-serif; }
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+    <header class="bg-white/30 backdrop-blur-md border border-white/20 shadow-sm sticky top-0 z-50">
+        <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../index.html" id="site-name" class="text-2xl font-bold text-teal-600">ডিজিটাল কেয়ার</a>
+            <div class="hidden md:flex space-x-6 items-center">
+                <a href="../about.html" class="text-gray-600 hover:text-teal-600">আমাদের সম্পর্কে</a>
+                <a href="../index.html#services" class="text-gray-600 hover:text-teal-600">সার্ভিসসমূহ</a>
+                <a href="../index.html#pricing" class="text-gray-600 hover:text-teal-600">মূল্য তালিকা</a>
+                <a href="../index.html#process" class="text-gray-600 hover:text-teal-600">আমাদের প্রক্রিয়া</a>
+                <a href="../index.html#faq" class="text-gray-600 hover:text-teal-600">জিজ্ঞাসা</a>
+                <a href="../index.html#contact" class="bg-teal-500 text-white px-4 py-2 rounded-full hover:bg-teal-600 transition duration-300">যোগাযোগ করুন</a>
+            </div>
+            <div class="md:hidden">
+                <button id="menu-btn" class="text-gray-600 focus:outline-none" aria-label="মেনু খুলুন বা বন্ধ করুন" aria-expanded="false">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path></svg>
+                </button>
+            </div>
+        </nav>
+        <div id="mobile-menu" class="md:hidden hidden px-6 pb-4 space-y-2">
+            <a href="../about.html" class="block text-gray-600 hover:text-teal-600">আমাদের সম্পর্কে</a>
+            <a href="../index.html#services" class="block text-gray-600 hover:text-teal-600">সার্ভিসসমূহ</a>
+            <a href="../index.html#pricing" class="block text-gray-600 hover:text-teal-600">মূল্য তালিকা</a>
+            <a href="../index.html#process" class="block text-gray-600 hover:text-teal-600">আমাদের প্রক্রিয়া</a>
+            <a href="../index.html#faq" class="block text-gray-600 hover:text-teal-600">জিজ্ঞাসা</a>
+            <a href="../index.html#contact" class="block bg-teal-500 text-white text-center px-4 py-2 rounded-full hover:bg-teal-600 transition duration-300">যোগাযোগ করুন</a>
+        </div>
+    </header>
+
+    <main>
+        <section class="bg-white py-20">
+            <div class="container mx-auto px-6 text-center">
+                <h1 class="text-4xl md:text-5xl font-bold text-gray-800">ডিজিটাল মার্কেটিং</h1>
+                <p class="text-lg text-gray-600 mt-4 max-w-3xl mx-auto">ফেসবুক ও গুগল বিজ্ঞাপনের মাধ্যমে আপনার প্রতিষ্ঠানের ব্র্যান্ড ভ্যালু বৃদ্ধি ও নতুন গ্রাহক আকর্ষণ করুন।</p>
+            </div>
+        </section>
+        <section class="py-20">
+            <div class="container mx-auto px-6">
+                <h2 class="text-3xl font-bold mb-6 text-center">আমাদের সেবার বৈশিষ্ট্য</h2>
+                <ul class="list-disc list-inside text-gray-600 space-y-2 max-w-3xl mx-auto">
+                    <li>লক্ষ্যভিত্তিক ফেসবুক ও গুগল বিজ্ঞাপন</li>
+                    <li>পেজ ও ক্যাম্পেইন অপ্টিমাইজেশন</li>
+                    <li>সঠিক অডিয়েন্স টার্গেটিং ও রিটার্গেটিং</li>
+                    <li>বিস্তারিত রিপোর্টিং ও অ্যানালিটিক্স</li>
+                </ul>
+            </div>
+        </section>
+    </main>
+
+    <footer class="bg-gray-800 text-white pt-16 pb-8">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
+                <div class="md:col-span-2">
+                    <h3 class="text-xl font-bold text-teal-500 mb-4">ডিজিটাল কেয়ার সলিউশনস</h3>
+                    <p class="text-gray-400">আমরা বাংলাদেশের স্বাস্থ্যসেবা প্রতিষ্ঠানগুলোকে আধুনিক প্রযুক্তির মাধ্যমে ডিজিটাল জগতে সফল হতে সাহায্য করি। আমাদের লক্ষ্য হলো আপনার এবং আপনার রোগীদের মধ্যে একটি নির্ভরযোগ্য ডিজিটাল সেতু তৈরি করা।</p>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">গুরুত্বপূর্ণ লিংক</h3>
+                    <ul class="space-y-2">
+                        <li><a href="../about.html" class="text-gray-400 hover:text-white">আমাদের সম্পর্কে</a></li>
+                        <li><a href="../index.html#services" class="text-gray-400 hover:text-white">সার্ভিসসমূহ</a></li>
+                        <li><a href="../index.html#pricing" class="text-gray-400 hover:text-white">মূল্য তালিকা</a></li>
+                        <li><a href="../index.html#process" class="text-gray-400 hover:text-white">আমাদের প্রক্রিয়া</a></li>
+                        <li><a href="../index.html#faq" class="text-gray-400 hover:text-white">সাধারণ জিজ্ঞাসা</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">যোগাযোগ</h3>
+                    <ul class="space-y-2 text-gray-400">
+                        <li class="flex items-start"><i class="fas fa-map-marker-alt mt-1 mr-2"></i>ডিকেপি রোড, বরগুনা</li>
+                        <li class="flex items-start"><i class="fas fa-phone mt-1 mr-2"></i>01639590392</li>
+                        <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2"></i>rahmatullahzisan@gmail.com</li>
+                    </ul>
+                    <div class="mt-4 flex space-x-4">
+                        <a href="#" class="text-gray-400 hover:text-white"><i class="fab fa-facebook-f fa-lg"></i></a>
+                        <a href="#" class="text-gray-400 hover:text-white"><i class="fab fa-linkedin-in fa-lg"></i></a>
+                        <a href="#" class="text-gray-400 hover:text-white"><i class="fab fa-youtube fa-lg"></i></a>
+                    </div>
+                </div>
+            </div>
+            <div class="border-t border-gray-700 pt-6 text-center text-gray-500">
+                <p>&copy; <span id="currentYear"></span> ডিজিটাল কেয়ার সলিউশনস। সর্বস্বত্ব সংরক্ষিত।</p>
+            </div>
+        </div>
+    </footer>
+    <script src="../main.js" defer></script>
+</body>
+</html>

--- a/services/web-development.html
+++ b/services/web-development.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="bn" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="ডিজিটাল কেয়ার সলিউশনস এর ওয়েব ডেভেলপমেন্ট সার্ভিস">
+    <title>ওয়েব ডেভেলপমেন্ট - ডিজিটাল কেয়ার সলিউশনস</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+        body { font-family: 'Hind Siliguri', sans-serif; }
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+    <!-- Header -->
+    <header class="bg-white/30 backdrop-blur-md border border-white/20 shadow-sm sticky top-0 z-50">
+        <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../index.html" id="site-name" class="text-2xl font-bold text-teal-600">ডিজিটাল কেয়ার</a>
+            <div class="hidden md:flex space-x-6 items-center">
+                <a href="../about.html" class="text-gray-600 hover:text-teal-600">আমাদের সম্পর্কে</a>
+                <a href="../index.html#services" class="text-gray-600 hover:text-teal-600">সার্ভিসসমূহ</a>
+                <a href="../index.html#pricing" class="text-gray-600 hover:text-teal-600">মূল্য তালিকা</a>
+                <a href="../index.html#process" class="text-gray-600 hover:text-teal-600">আমাদের প্রক্রিয়া</a>
+                <a href="../index.html#faq" class="text-gray-600 hover:text-teal-600">জিজ্ঞাসা</a>
+                <a href="../index.html#contact" class="bg-teal-500 text-white px-4 py-2 rounded-full hover:bg-teal-600 transition duration-300">যোগাযোগ করুন</a>
+            </div>
+            <div class="md:hidden">
+                <button id="menu-btn" class="text-gray-600 focus:outline-none" aria-label="মেনু খুলুন বা বন্ধ করুন" aria-expanded="false">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path></svg>
+                </button>
+            </div>
+        </nav>
+        <div id="mobile-menu" class="md:hidden hidden px-6 pb-4 space-y-2">
+            <a href="../about.html" class="block text-gray-600 hover:text-teal-600">আমাদের সম্পর্কে</a>
+            <a href="../index.html#services" class="block text-gray-600 hover:text-teal-600">সার্ভিসসমূহ</a>
+            <a href="../index.html#pricing" class="block text-gray-600 hover:text-teal-600">মূল্য তালিকা</a>
+            <a href="../index.html#process" class="block text-gray-600 hover:text-teal-600">আমাদের প্রক্রিয়া</a>
+            <a href="../index.html#faq" class="block text-gray-600 hover:text-teal-600">জিজ্ঞাসা</a>
+            <a href="../index.html#contact" class="block bg-teal-500 text-white text-center px-4 py-2 rounded-full hover:bg-teal-600 transition duration-300">যোগাযোগ করুন</a>
+        </div>
+    </header>
+
+    <main>
+        <section class="bg-white py-20">
+            <div class="container mx-auto px-6 text-center">
+                <h1 class="text-4xl md:text-5xl font-bold text-gray-800">ওয়েব ডেভেলপমেন্ট</h1>
+                <p class="text-lg text-gray-600 mt-4 max-w-3xl mx-auto">আপনার হাসপাতাল বা ক্লিনিকের জন্য একটি আধুনিক, নিরাপদ এবং মোবাইল ফ্রেন্ডলি ওয়েবসাইট তৈরি করি যাতে আপনার গ্রাহকরা সহজেই তথ্য পেতে পারেন।</p>
+            </div>
+        </section>
+        <section class="py-20">
+            <div class="container mx-auto px-6">
+                <h2 class="text-3xl font-bold mb-6 text-center">আমাদের সেবার বৈশিষ্ট্য</h2>
+                <ul class="list-disc list-inside text-gray-600 space-y-2 max-w-3xl mx-auto">
+                    <li>রেসপন্সিভ ও মোবাইল ফ্রেন্ডলি ডিজাইন</li>
+                    <li>কাস্টম ডোমেইন ও হোস্টিং সেটআপ</li>
+                    <li>এসইও অপ্টিমাইজড কনটেন্ট</li>
+                    <li>সহজে ব্যবহারযোগ্য কনটেন্ট ম্যানেজমেন্ট সিস্টেম</li>
+                </ul>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-gray-800 text-white pt-16 pb-8">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
+                <div class="md:col-span-2">
+                    <h3 class="text-xl font-bold text-teal-500 mb-4">ডিজিটাল কেয়ার সলিউশনস</h3>
+                    <p class="text-gray-400">আমরা বাংলাদেশের স্বাস্থ্যসেবা প্রতিষ্ঠানগুলোকে আধুনিক প্রযুক্তির মাধ্যমে ডিজিটাল জগতে সফল হতে সাহায্য করি। আমাদের লক্ষ্য হলো আপনার এবং আপনার রোগীদের মধ্যে একটি নির্ভরযোগ্য ডিজিটাল সেতু তৈরি করা।</p>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">গুরুত্বপূর্ণ লিংক</h3>
+                    <ul class="space-y-2">
+                        <li><a href="../about.html" class="text-gray-400 hover:text-white">আমাদের সম্পর্কে</a></li>
+                        <li><a href="../index.html#services" class="text-gray-400 hover:text-white">সার্ভিসসমূহ</a></li>
+                        <li><a href="../index.html#pricing" class="text-gray-400 hover:text-white">মূল্য তালিকা</a></li>
+                        <li><a href="../index.html#process" class="text-gray-400 hover:text-white">আমাদের প্রক্রিয়া</a></li>
+                        <li><a href="../index.html#faq" class="text-gray-400 hover:text-white">সাধারণ জিজ্ঞাসা</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-4">যোগাযোগ</h3>
+                    <ul class="space-y-2 text-gray-400">
+                        <li class="flex items-start"><i class="fas fa-map-marker-alt mt-1 mr-2"></i>ডিকেপি রোড, বরগুনা</li>
+                        <li class="flex items-start"><i class="fas fa-phone mt-1 mr-2"></i>01639590392</li>
+                        <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2"></i>rahmatullahzisan@gmail.com</li>
+                    </ul>
+                    <div class="mt-4 flex space-x-4">
+                        <a href="#" class="text-gray-400 hover:text-white"><i class="fab fa-facebook-f fa-lg"></i></a>
+                        <a href="#" class="text-gray-400 hover:text-white"><i class="fab fa-linkedin-in fa-lg"></i></a>
+                        <a href="#" class="text-gray-400 hover:text-white"><i class="fab fa-youtube fa-lg"></i></a>
+                    </div>
+                </div>
+            </div>
+            <div class="border-t border-gray-700 pt-6 text-center text-gray-500">
+                <p>&copy; <span id="currentYear"></span> ডিজিটাল কেয়ার সলিউশনস। সর্বস্বত্ব সংরক্ষিত।</p>
+            </div>
+        </div>
+    </footer>
+    <script src="../main.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add dedicated service pages for web development, AI chatbot, and digital marketing
- Link main service cards on the homepage to their respective detailed pages

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a0432d6d60832a9f3815413d8cf2a2