### PR TITLE
Fix header logo color when footer overlaps

### DIFF
--- a/main.js
+++ b/main.js
@@ -136,16 +136,21 @@ if (orderForm) {
 const siteName = document.getElementById('site-name');
 const contactSection = document.getElementById('contact');
 const header = document.querySelector('header');
+const footer = document.querySelector('footer');
 
-if (siteName && contactSection && header) {
+if (siteName && contactSection && header && footer) {
     const defaultClass = 'text-teal-600';
     const overlapClass = 'text-white';
 
     function updateSiteNameColor() {
-        const contactRect = contactSection.getBoundingClientRect();
         const headerHeight = header.offsetHeight;
+        const contactRect = contactSection.getBoundingClientRect();
+        const footerRect = footer.getBoundingClientRect();
 
-        if (contactRect.top <= headerHeight && contactRect.bottom >= headerHeight) {
+        const inContact = contactRect.top <= headerHeight && contactRect.bottom >= headerHeight;
+        const inFooter = footerRect.top <= headerHeight && footerRect.bottom >= headerHeight;
+
+        if (inContact && !inFooter) {
             siteName.classList.remove(defaultClass);
             siteName.classList.add(overlapClass);
         } else {


### PR DESCRIPTION
## Summary
- Reset header site-name color when scrolling past the contact section so it reverts before overlapping the footer

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a0a34639cc832a8377c4a980c43ca4