### PR TITLE
Keep header site-name white over footer

### DIFF
--- a/main.js
+++ b/main.js
@@ -132,20 +132,25 @@ if (orderForm) {
     });
 }
 
-// Change site name color only when header overlaps the contact section
+// Change site name color when header overlaps the contact section or footer
 const siteName = document.getElementById('site-name');
 const contactSection = document.getElementById('contact');
 const header = document.querySelector('header');
+const footer = document.querySelector('footer');
 
-if (siteName && contactSection && header) {
+if (siteName && contactSection && header && footer) {
     const defaultClass = 'text-teal-600';
     const overlapClass = 'text-white';
 
     function updateSiteNameColor() {
-        const contactRect = contactSection.getBoundingClientRect();
         const headerHeight = header.offsetHeight;
+        const contactRect = contactSection.getBoundingClientRect();
+        const footerRect = footer.getBoundingClientRect();
 
-        if (contactRect.top <= headerHeight && contactRect.bottom >= headerHeight) {
+        const inContact = contactRect.top <= headerHeight && contactRect.bottom >= headerHeight;
+        const inFooter = footerRect.top <= headerHeight && footerRect.bottom >= headerHeight;
+
+        if (inContact || inFooter) {
             siteName.classList.remove(defaultClass);
             siteName.classList.add(overlapClass);
         } else {
@@ -155,7 +160,7 @@ if (siteName && contactSection && header) {
     }
 
     window.addEventListener('scroll', updateSiteNameColor);
-    // Run on load in case user refreshes while on contact section
+    // Run on load in case user refreshes while on contact or footer section
     updateSiteNameColor();
 }
 


### PR DESCRIPTION
## Summary
- Keep header site-name white when overlapping contact section or footer

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a0a34639cc832a8377c4a980c43ca4