### PR TITLE
Add demo and Facebook links to case study

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,23 @@
                     <iframe class="absolute top-0 left-0 w-full h-full" src="https://www.loom.com/embed/e841968879404cc59946119d05883760?sid=251e2ee1-dfa7-470f-a4c5-45ee1b0a6127" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
                 </div>
 
+                <div class="text-center mt-10 flex flex-col sm:flex-row justify-center items-center gap-4">
+                    <a 
+                        href="https://online-bazar.top/" 
+                        target="_blank" 
+                        rel="noopener noreferrer"
+                        class="inline-block bg-gray-800 text-white font-semibold px-6 py-3 rounded-full hover:bg-gray-700 transition duration-300">
+                        <i class="fas fa-external-link-alt mr-2"></i> লাইভ ডেমো দেখুন
+                    </a>
+                    <a 
+                        href="https://www.facebook.com/onlinebazarbarguna" 
+                        target="_blank" 
+                        rel="noopener noreferrer"
+                        class="inline-block bg-blue-600 text-white font-semibold px-6 py-3 rounded-full hover:bg-blue-700 transition duration-300">
+                        <i class="fab fa-facebook-f mr-2"></i> ফেসবুক পেজ ভিজিট করুন
+                    </a>
+                </div>
+
                 <div class="text-center mt-12">
                     <a href="#contact" class="inline-block bg-teal-500 text-white text-lg font-semibold px-8 py-4 rounded-full hover:bg-teal-600 transition duration-300">আপনার ব্যবসার জন্য এমন সমাধান চান?</a>
                 </div>


### PR DESCRIPTION
## Summary
- Add dual button block under case study video to link to live demo and Facebook page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a11ea903b8832a956a467394359979