### PR TITLE
Remove obsolete pricing card focus script

### DIFF
--- a/main.js
+++ b/main.js
@@ -217,27 +217,3 @@ document.addEventListener("DOMContentLoaded", () => {
     // Trigger on load
     handleScrollAnimation();
 });
-
-
-// Pricing Card Focus Effect on Desktop
-document.addEventListener("DOMContentLoaded", () => {
-    const mainCard = document.getElementById('pricing-card-main');
-    const sideCard1 = document.getElementById('pricing-card-1');
-    const sideCard3 = document.getElementById('pricing-card-3');
-
-    if (mainCard && sideCard1 && sideCard3) {
-        mainCard.addEventListener('mouseenter', () => {
-            if (window.innerWidth >= 1024) { // Only apply on lg screens and up
-                sideCard1.classList.add('defocused');
-                sideCard3.classList.add('defocused');
-            }
-        });
-
-        mainCard.addEventListener('mouseleave', () => {
-            if (window.innerWidth >= 1024) {
-                sideCard1.classList.remove('defocused');
-                sideCard3.classList.remove('defocused');
-            }
-        });
-    }
-});


### PR DESCRIPTION
## Summary
- remove unused desktop pricing card focus behavior from main.js

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a1a82fb3a4832aabbd3c3c4b163d3f