### PR TITLE
Refine clinic demo CTA and add chat widget

### DIFF
--- a/clinic-demo.html
+++ b/clinic-demo.html
@@ -149,16 +149,11 @@
             WhatsApp/Messenger–এ ২৪/৭ রোগী সাপোর্ট চালু করে—যাতে সম্ভাব্য রোগী
             একটিও হারিয়ে না যায়।
           </p>
-          <div class="flex flex-col sm:flex-row justify-center gap-4">
+          <div class="flex justify-center">
             <a
-              href="/clinic-demo"
+              href="/start-trial"
               class="bg-teal-500 text-white px-6 py-3 rounded-full hover:bg-teal-600"
-              >ডেমো দেখুন →</a
-            >
-            <a
-              href="/book-call"
-              class="bg-gray-800 text-white px-6 py-3 rounded-full hover:bg-gray-700"
-              >১৫-মিনিট কল বুক করুন →</a
+              >ফ্রি ট্রায়াল শুরু করুন →</a
             >
           </div>
         </div>
@@ -293,9 +288,9 @@
             </li>
           </ol>
           <a
-            href="/clinic-demo"
+            href="/start-trial"
             class="inline-block bg-teal-500 text-white px-6 py-3 rounded-full hover:bg-teal-600"
-            >এখনই ডেমো চালু করুন →</a
+            >ফ্রি ট্রায়াল শুরু করুন →</a
           >
         </div>
       </section>
@@ -366,16 +361,11 @@
               রিপোর্টিং ড্যাশবোর্ড
             </li>
           </ul>
-          <div class="flex flex-col sm:flex-row justify-center gap-4">
+          <div class="flex justify-center">
             <a
-              href="/clinic-demo"
+              href="/start-trial"
               class="bg-teal-500 text-white px-6 py-3 rounded-full hover:bg-teal-600"
-              >ডেমো দেখুন</a
-            >
-            <a
-              href="/book-call"
-              class="bg-gray-800 text-white px-6 py-3 rounded-full hover:bg-gray-700"
-              >কনসাল্ট বুক করুন</a
+              >ফ্রি ট্রায়াল শুরু করুন</a
             >
           </div>
         </div>
@@ -441,16 +431,11 @@
             আপনার ক্লিনিকের জন্য ৭ দিনে লাইভ প্রুফ দেখাই—লিড/বুকিং বাড়বে, নো-শো
             কমবে।
           </h2>
-          <div class="flex flex-col sm:flex-row justify-center gap-4">
+          <div class="flex justify-center">
             <a
               href="/start-trial"
               class="bg-white text-teal-600 px-6 py-3 rounded-full hover:bg-gray-100"
               >ফ্রি ট্রায়াল শুরু করুন</a
-            >
-            <a
-              href="/book-call"
-              class="bg-teal-800 text-white px-6 py-3 rounded-full hover:bg-teal-700"
-              >১৫-মিনিট কল বুক করুন</a
             >
           </div>
         </div>
@@ -529,6 +514,19 @@
         </div>
       </div>
     </footer>
+
+    <!-- Live Chat Widget -->
+    <script>
+      window.embeddedChatbotConfig = {
+        chatbotId: "REPLACE_WITH_CHATBOT_ID",
+        domain: "www.chatbase.co"
+      };
+    </script>
+    <script
+      src="https://www.chatbase.co/embed.min.js"
+      chatbotId="REPLACE_WITH_CHATBOT_ID"
+      defer
+    ></script>
 
     <script src="main.js" defer></script>
   </body>


### PR DESCRIPTION
## Summary
- Simplify clinic demo page to use a single primary CTA focused on starting a free trial
- Remove secondary CTAs and unify messaging to "ফ্রি ট্রায়াল শুরু করুন"
- Embed a live chat widget placeholder for an interactive demo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a3ba44f328832a9ef6e00acad85fc0