### PR TITLE
Add dark mode button styles

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,6 +15,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="dark-mode.css">
     <style>
         body { font-family: 'Hind Siliguri', sans-serif; }
 

--- a/affiliate.html
+++ b/affiliate.html
@@ -15,6 +15,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="dark-mode.css">
     <style>
         body { font-family: 'Hind Siliguri', sans-serif; }
     </style>

--- a/blog.html
+++ b/blog.html
@@ -10,6 +10,7 @@
     <meta name="description" content="ডিজিটাল মার্কেটিং, এআই অটোমেশন ও ব্যবসা উন্নয়নের ট্রেন্ড জানতে আমাদের ব্লগ পড়ুন। কার্যকর কৌশল ও বাস্তব উদাহরণ আপনার অনলাইন উপস্থিতি ও বিক্রি বাড়াতে সাহায্য করবে।">
     <meta property="og:description" content="ডিজিটাল মার্কেটিং, এআই অটোমেশন ও ব্যবসা উন্নয়নের ট্রেন্ড জানতে আমাদের ব্লগ পড়ুন। কার্যকর কৌশল ও বাস্তব উদাহরণ আপনার অনলাইন উপস্থিতি ও বিক্রি বাড়াতে সাহায্য করবে।">
     <link rel="canonical" href="https://www.digitalcare.site/blog">
+    <link rel="stylesheet" href="dark-mode.css">
     <style>
         body { font-family: 'Hind Siliguri', sans-serif; }
 

--- a/blog/ai-chatbot-business-growth.html
+++ b/blog/ai-chatbot-business-growth.html
@@ -15,6 +15,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTQOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../dark-mode.css">
     <style>
         body { font-family: 'Hind Siliguri', sans-serif; }
 

--- a/blog/digital-marketing-trends-2025.html
+++ b/blog/digital-marketing-trends-2025.html
@@ -15,6 +15,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTQOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../dark-mode.css">
     <style>
         body { font-family: 'Hind Siliguri', sans-serif; }
 

--- a/blog/post1.html
+++ b/blog/post1.html
@@ -15,6 +15,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTQOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../dark-mode.css">
     <style>
         body { font-family: 'Hind Siliguri', sans-serif; }
 

--- a/blog/social-media-for-business.html
+++ b/blog/social-media-for-business.html
@@ -15,6 +15,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTQOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../dark-mode.css">
     <style>
         body { font-family: 'Hind Siliguri', sans-serif; }
 

--- a/clinic-demo.html
+++ b/clinic-demo.html
@@ -21,6 +21,7 @@
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+    <link rel="stylesheet" href="dark-mode.css">
       integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -46,3 +46,23 @@ html.dark #faq button {
 html.dark #faq button:hover {
   background-color: #475569;
 }
+
+/* Primary Buttons */
+html.dark .bg-teal-500 {
+  background-color: #0d9488 !important; /* Teal-600 */
+  color: #f0fdfa !important; /* Teal-50 */
+}
+html.dark .bg-teal-500:hover {
+  background-color: #0f766e !important; /* Teal-700 */
+}
+
+/* Secondary/Bordered Buttons */
+html.dark .border-teal-500 {
+  border-color: #2dd4bf !important; /* Teal-400 */
+  color: #2dd4bf !important; /* Teal-400 */
+}
+html.dark .border-teal-500:hover {
+  background-color: #2dd4bf !important; /* Teal-400 */
+  color: #0f172a !important; /* Dark background color */
+}
+

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     
     <!-- Font Awesome for Icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="dark-mode.css">
 
     <style>
         /* Applying Bengali font to the entire page */

--- a/main.js
+++ b/main.js
@@ -1,8 +1,4 @@
-// Dark mode stylesheet and initial theme
-const darkModeStylesheet = document.createElement('link');
-darkModeStylesheet.rel = 'stylesheet';
-darkModeStylesheet.href = document.currentScript.src.replace(/main\.js$/, 'dark-mode.css');
-document.head.appendChild(darkModeStylesheet);
+// Set initial theme
 
 if (localStorage.getItem('theme') === 'dark') {
     document.documentElement.classList.add('dark');

--- a/services.html
+++ b/services.html
@@ -15,6 +15,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTQOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="dark-mode.css">
     <style>
         body { font-family: 'Hind Siliguri', sans-serif; }
 

--- a/services/ai-chatbot.html
+++ b/services/ai-chatbot.html
@@ -15,6 +15,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../dark-mode.css">
     <style>
         body { font-family: 'Hind Siliguri', sans-serif; }
 

--- a/services/digital-marketing.html
+++ b/services/digital-marketing.html
@@ -23,6 +23,7 @@
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+    <link rel="stylesheet" href="../dark-mode.css">
       integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"

--- a/services/facebook-automation.html
+++ b/services/facebook-automation.html
@@ -16,6 +16,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../dark-mode.css">
     <style>
         body { font-family: 'Hind Siliguri', sans-serif; }
 

--- a/services/web-development.html
+++ b/services/web-development.html
@@ -16,6 +16,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../dark-mode.css">
     <style>
         body { font-family: 'Hind Siliguri', sans-serif; }
 


### PR DESCRIPTION
## Summary
- style teal buttons in dark mode with teal palette for backgrounds, borders, and text
- link dark mode stylesheet on every page and remove dynamic injection from main script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a9c5302124832a96675b654fcb1f76